### PR TITLE
Fix typo, Langages -> Languages

### DIFF
--- a/demo.typ
+++ b/demo.typ
@@ -13,7 +13,7 @@
     - +33 6 66 66 66 66
     - 10 Downing Street, London
 
-    = Langages
+    = Languages
 
     - French : native
     - English : C1


### PR DESCRIPTION
Found via `typos --hidden --format brief`

Note that I cannot update the `demo.pdf` as it will change the default font.