### PR TITLE
Fix images being cropped in the "aside" part

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -47,9 +47,7 @@
         }
         body
     }),
-    {
-      v(20pt)
-      set block(inset: (left: 0.4 * margin, right: 0.4 * margin))
+    block(inset: (bottom: margin, rest: 0.4 * margin), width: 100%, {
       show heading: it => align(right, upper(it))
       set list(marker: "")
       show list: it => {
@@ -58,6 +56,6 @@
         align(right, it)
       }
       aside
-    }
+    }),
   )
 }


### PR DESCRIPTION
Updates the aside column to be wrapped in a block() function, similar to the main column. Removing the set-rule on block() avoids side-effects upon the content of "aside".

The "v(20pt)" spacing part is replaced by the inset of the wrapping block() function for consistency with the main column.

Fixes #8.